### PR TITLE
Remove lodash dependency

### DIFF
--- a/lib/bruteforce.js
+++ b/lib/bruteforce.js
@@ -4,7 +4,6 @@
 /* eslint no-use-before-define:0 */
 
 var debug = require("debug")("talon");
-var _ = require("lodash");
 
 
 module.exports = {
@@ -216,11 +215,13 @@ function extractSignature (msgBody) {
 function getSignatureCandidate (lines) {
   debug("getSignatureCandidate", lines);
   // keep only non-empty lines: ["hello", "", "world"] → [0, 2]
-  var nonEmpty = _.filter(_.map(lines, function (line, index) {
-    return (line && line.trim()) ? index : null;
-  }), function isNotNull (index) {
-    return index !== null;
-  });
+  var nonEmpty = lines
+    .map(function (line, index) {
+      return (line && line.trim()) ? index : null
+    })
+    .filter(function (index) {
+      return index !== null
+    });
   debug("nonEmpty", nonEmpty);
 
   // if message is empty or just one line then there is no signature
@@ -263,7 +264,7 @@ function markCandidateIndices (lines, candidateIndices) {
   // that did not seem very logical so I mark from the top to bottom here
   debug("markCandidateIndices", lines, candidateIndices);
   var markers = "";
-  _.forEachRight(candidateIndices, function (lineIdx) {
+  candidateIndices.slice().reverse().forEach(function (lineIdx) {
     var line = lines[lineIdx].trim();
     if (lineLengthIgnoringURLs(line) > TOO_LONG_SIGNATURE_LINE) {
       markers += "l"; // Marked as too long
@@ -293,7 +294,7 @@ function processMarkedCandidateIndices (candidateIndices, markers) {
     return [];
   }
 
-  var found = _.filter(match)[1] || "";
+  var found = match.filter(Boolean)[1] || "";
   var end = match.index + found.length;
 
   var candidates = candidateIndices.slice(-end);

--- a/package.json
+++ b/package.json
@@ -21,8 +21,7 @@
   },
   "homepage": "https://github.com/lmtm/node-talon",
   "dependencies": {
-    "debug": "^2.1.1",
-    "lodash": "^3.2.0"
+    "debug": "^2.1.1"
   },
   "devDependencies": {
     "chai": "^2.0.0",


### PR DESCRIPTION
Lodash v3 triggers "critical" security warnings when installing `talon` with npm.

I removed the lodash dependency since all usages of it can easily be replaced with APIs that are still available in all old Node versions tested in CI (while the patched lodash version is only compatible with Node 18 and up).